### PR TITLE
feat: 데이터 응답 처리 로직을 인터셉터로 이동

### DIFF
--- a/app/src/main/java/com/ourbalance/di/RemoteModule.kt
+++ b/app/src/main/java/com/ourbalance/di/RemoteModule.kt
@@ -3,6 +3,7 @@ package com.ourbalance.di
 import com.ourbalance.BuildConfig
 import com.ourbalance.data.api.AuthService
 import com.ourbalance.data.api.BalanceService
+import com.ourbalance.data.api.ResponseUnboxingInterceptor
 import com.ourbalance.data.api.TokenInterceptor
 import dagger.Module
 import dagger.Provides
@@ -35,9 +36,11 @@ object RemoteModule {
     @Provides
     @Singleton
     fun providesDefaultOkHttpClient(
-        interceptor: TokenInterceptor
+        tokenInterceptor: TokenInterceptor,
+        unboxingInterceptor: ResponseUnboxingInterceptor
     ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(interceptor)
+        .addInterceptor(tokenInterceptor)
+        .addInterceptor(unboxingInterceptor)
         .build()
 
     @Provides

--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -19,7 +19,11 @@ object Libs {
 
     object Test {
         const val JUNIT = "junit:junit:${Version.JUNIT}"
+        const val JUNIT_JUPITER = "org.junit.jupiter:junit-jupiter:${Version.JUPITER}"
+        const val ASSERTJ = "org.assertj:assertj-core:${Version.ASSERTJ}"
         const val MOCK_WEB_SERVER = "com.squareup.okhttp3:mockwebserver:${Version.OKHTTP}"
+        const val MOCKK = "io.mockk:mockk:${Version.MOCKK}"
+        const val JSON = "org.json:json:20180813"
     }
 
     object AndroidTest {

--- a/buildSrc/src/main/java/Version.kt
+++ b/buildSrc/src/main/java/Version.kt
@@ -13,4 +13,7 @@ object Version {
     const val TIMBER = "5.0.1"
     const val COROUTINES = "1.6.4"
     const val DATASTORE = "1.0.0"
+    const val MOCKK = "1.11.0"
+    const val JUPITER = "5.9.1"
+    const val ASSERTJ = "3.11.1"
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -17,5 +17,10 @@ dependencies {
     implementation(Libs.Timber.TIMBER)
     implementation(Libs.Coroutines.CORE)
     implementation(Libs.DataStore.DATASTORE)
+    testImplementation(Libs.Test.JUNIT)
+    testImplementation(Libs.Test.JUNIT_JUPITER)
+    testImplementation(Libs.Test.ASSERTJ)
     testImplementation(Libs.Test.MOCK_WEB_SERVER)
+    testImplementation(Libs.Test.MOCKK)
+    testImplementation(Libs.Test.JSON)
 }

--- a/data/src/main/java/com/ourbalance/data/api/AuthService.kt
+++ b/data/src/main/java/com/ourbalance/data/api/AuthService.kt
@@ -1,7 +1,7 @@
 package com.ourbalance.data.api
 
 import com.ourbalance.data.entity.BaseResponse
-import com.ourbalance.data.entity.UserInfoEntity
+import com.ourbalance.data.entity.user.UserInfoEntity
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/data/src/main/java/com/ourbalance/data/api/BalanceService.kt
+++ b/data/src/main/java/com/ourbalance/data/api/BalanceService.kt
@@ -1,6 +1,5 @@
 package com.ourbalance.data.api
 
-import com.ourbalance.data.entity.BaseResponse
 import com.ourbalance.data.entity.balance.BalanceDetailEntity
 import com.ourbalance.data.entity.balance.BalanceListResponse
 import retrofit2.http.GET
@@ -8,10 +7,10 @@ import retrofit2.http.Path
 
 interface BalanceService {
     @GET("/balance")
-    fun getBalanceList(): BaseResponse<BalanceListResponse>
+    fun getBalanceList(): BalanceListResponse
 
     @GET("/balance/{id}")
     fun getBalanceDetail(
         @Path("id") id: Long
-    ): BaseResponse<BalanceDetailEntity>
+    ): BalanceDetailEntity
 }

--- a/data/src/main/java/com/ourbalance/data/api/ResponseUnboxingInterceptor.kt
+++ b/data/src/main/java/com/ourbalance/data/api/ResponseUnboxingInterceptor.kt
@@ -1,0 +1,36 @@
+package com.ourbalance.data.api
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.json.JSONObject
+import timber.log.Timber
+
+class ResponseUnboxingInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        val responseJson = response.extractResponseJson()
+        val payload = if (responseJson.has(KEY_DATA)) responseJson[KEY_DATA] else EMPTY_JSON
+
+        return response.newBuilder()
+            .message(responseJson[KEY_ERROR_MESSAGE].toString())
+            .body(payload.toString().toResponseBody())
+            .build()
+    }
+
+    private fun Response.extractResponseJson(): JSONObject {
+        val jsonString = this.body?.string() ?: EMPTY_JSON
+        return try {
+            JSONObject(jsonString)
+        } catch (e: Throwable) {
+            Timber.d("서버 응답 오류 : $jsonString")
+            throw Throwable(message = e.message)
+        }
+    }
+
+    companion object {
+        const val EMPTY_JSON = "{}"
+        const val KEY_DATA = "data"
+        const val KEY_ERROR_MESSAGE = "error"
+    }
+}

--- a/data/src/main/java/com/ourbalance/data/entity/mapper/UserInfoMapper.kt
+++ b/data/src/main/java/com/ourbalance/data/entity/mapper/UserInfoMapper.kt
@@ -1,6 +1,6 @@
 package com.ourbalance.data.entity.mapper
 
-import com.ourbalance.data.entity.UserInfoEntity
+import com.ourbalance.data.entity.user.UserInfoEntity
 import com.ourbalance.domain.model.UserInfo
 
 fun UserInfoEntity.toModel(): UserInfo {

--- a/data/src/main/java/com/ourbalance/data/entity/user/UserInfoEntity.kt
+++ b/data/src/main/java/com/ourbalance/data/entity/user/UserInfoEntity.kt
@@ -1,4 +1,4 @@
-package com.ourbalance.data.entity
+package com.ourbalance.data.entity.user
 
 data class UserInfoEntity(
     val email: String,

--- a/data/src/main/java/com/ourbalance/data/ext/RemoteExtension.kt
+++ b/data/src/main/java/com/ourbalance/data/ext/RemoteExtension.kt
@@ -14,11 +14,3 @@ fun <T> getAuthResponse(response: BaseResponse<T>): Result<T> {
         Result.Error(e.message ?: "Unknown Error")
     }
 }
-
-fun <T> getResponse(response: T): T {
-    return try {
-        response
-    } catch (e: Throwable) {
-        throw e
-    }
-}

--- a/data/src/main/java/com/ourbalance/data/ext/RemoteExtension.kt
+++ b/data/src/main/java/com/ourbalance/data/ext/RemoteExtension.kt
@@ -3,7 +3,7 @@ package com.ourbalance.data.ext
 import com.ourbalance.data.entity.BaseResponse
 import com.ourbalance.domain.result.Result
 
-fun <T> getAuthResponse(response: BaseResponse<T>): Result<T> {
+fun <T> getResponse(response: BaseResponse<T>): Result<T> {
     return try {
         if (response.status == 200) {
             Result.Success(response.data!!)

--- a/data/src/main/java/com/ourbalance/data/ext/RemoteExtension.kt
+++ b/data/src/main/java/com/ourbalance/data/ext/RemoteExtension.kt
@@ -3,14 +3,22 @@ package com.ourbalance.data.ext
 import com.ourbalance.data.entity.BaseResponse
 import com.ourbalance.domain.result.Result
 
-fun <T> getResponse(block: BaseResponse<T>): Result<T> {
+fun <T> getAuthResponse(response: BaseResponse<T>): Result<T> {
     return try {
-        if (block.status == 200) {
-            Result.Success(block.data!!)
+        if (response.status == 200) {
+            Result.Success(response.data!!)
         } else {
-            Result.Error(block.error!!)
+            Result.Error(response.error!!)
         }
     } catch (e: Throwable) {
         Result.Error(e.message ?: "Unknown Error")
+    }
+}
+
+fun <T> getResponse(response: T): T {
+    return try {
+        response
+    } catch (e: Throwable) {
+        throw e
     }
 }

--- a/data/src/main/java/com/ourbalance/data/repository/BalanceRepositoryImpl.kt
+++ b/data/src/main/java/com/ourbalance/data/repository/BalanceRepositoryImpl.kt
@@ -4,17 +4,16 @@ import com.ourbalance.data.source.remote.balance.BalanceDataSource
 import com.ourbalance.domain.model.BalanceDetail
 import com.ourbalance.domain.model.BalanceInfo
 import com.ourbalance.domain.repository.BalanceRepository
-import com.ourbalance.domain.result.Result
 import javax.inject.Inject
 
 class BalanceRepositoryImpl @Inject constructor(
     private val balanceDataSource: BalanceDataSource
 ) : BalanceRepository {
-    override suspend fun getBalanceList(): Result<List<BalanceInfo>> {
+    override suspend fun getBalanceList(): List<BalanceInfo> {
         return balanceDataSource.getBalanceList()
     }
 
-    override suspend fun getBalanceDetail(id: Long): Result<BalanceDetail> {
+    override suspend fun getBalanceDetail(id: Long): BalanceDetail {
         return balanceDataSource.getBalanceDetail(id)
     }
 }

--- a/data/src/main/java/com/ourbalance/data/source/remote/auth/AuthDataSourceImpl.kt
+++ b/data/src/main/java/com/ourbalance/data/source/remote/auth/AuthDataSourceImpl.kt
@@ -2,7 +2,7 @@ package com.ourbalance.data.source.remote.auth
 
 import com.ourbalance.data.api.AuthService
 import com.ourbalance.data.entity.mapper.toEntity
-import com.ourbalance.data.ext.getResponse
+import com.ourbalance.data.ext.getAuthResponse
 import com.ourbalance.data.source.local.PreferenceStorage
 import com.ourbalance.domain.model.UserInfo
 import com.ourbalance.domain.result.Result
@@ -14,7 +14,7 @@ class AuthDataSourceImpl @Inject constructor(
     private val prefs: PreferenceStorage
 ) : AuthDataSource {
     override suspend fun login(userInfo: UserInfo): Result<Unit> {
-        return when (val response = getResponse(authService.login(userInfo.toEntity()))) {
+        return when (val response = getAuthResponse(authService.login(userInfo.toEntity()))) {
             is Result.Success -> {
                 saveToken(response.data)
                 Result.Success(Unit)
@@ -24,7 +24,7 @@ class AuthDataSourceImpl @Inject constructor(
     }
 
     override suspend fun signup(userInfo: UserInfo): Result<Unit> {
-        return getResponse(authService.signup(userInfo.toEntity()))
+        return getAuthResponse(authService.signup(userInfo.toEntity()))
     }
 
     override suspend fun saveToken(token: String) {

--- a/data/src/main/java/com/ourbalance/data/source/remote/auth/AuthDataSourceImpl.kt
+++ b/data/src/main/java/com/ourbalance/data/source/remote/auth/AuthDataSourceImpl.kt
@@ -2,7 +2,7 @@ package com.ourbalance.data.source.remote.auth
 
 import com.ourbalance.data.api.AuthService
 import com.ourbalance.data.entity.mapper.toEntity
-import com.ourbalance.data.ext.getAuthResponse
+import com.ourbalance.data.ext.getResponse
 import com.ourbalance.data.source.local.PreferenceStorage
 import com.ourbalance.domain.model.UserInfo
 import com.ourbalance.domain.result.Result
@@ -14,7 +14,7 @@ class AuthDataSourceImpl @Inject constructor(
     private val prefs: PreferenceStorage
 ) : AuthDataSource {
     override suspend fun login(userInfo: UserInfo): Result<Unit> {
-        return when (val response = getAuthResponse(authService.login(userInfo.toEntity()))) {
+        return when (val response = getResponse(authService.login(userInfo.toEntity()))) {
             is Result.Success -> {
                 saveToken(response.data)
                 Result.Success(Unit)
@@ -24,7 +24,7 @@ class AuthDataSourceImpl @Inject constructor(
     }
 
     override suspend fun signup(userInfo: UserInfo): Result<Unit> {
-        return getAuthResponse(authService.signup(userInfo.toEntity()))
+        return getResponse(authService.signup(userInfo.toEntity()))
     }
 
     override suspend fun saveToken(token: String) {

--- a/data/src/main/java/com/ourbalance/data/source/remote/balance/BalanceDataSource.kt
+++ b/data/src/main/java/com/ourbalance/data/source/remote/balance/BalanceDataSource.kt
@@ -2,9 +2,8 @@ package com.ourbalance.data.source.remote.balance
 
 import com.ourbalance.domain.model.BalanceDetail
 import com.ourbalance.domain.model.BalanceInfo
-import com.ourbalance.domain.result.Result
 
 interface BalanceDataSource {
-    suspend fun getBalanceList(): Result<List<BalanceInfo>>
-    suspend fun getBalanceDetail(id: Long): Result<BalanceDetail>
+    suspend fun getBalanceList(): List<BalanceInfo>
+    suspend fun getBalanceDetail(id: Long): BalanceDetail
 }

--- a/data/src/main/java/com/ourbalance/data/source/remote/balance/BalanceDataSourceImpl.kt
+++ b/data/src/main/java/com/ourbalance/data/source/remote/balance/BalanceDataSourceImpl.kt
@@ -2,7 +2,6 @@ package com.ourbalance.data.source.remote.balance
 
 import com.ourbalance.data.api.BalanceService
 import com.ourbalance.data.entity.mapper.toModel
-import com.ourbalance.data.ext.getResponse
 import com.ourbalance.domain.model.BalanceDetail
 import com.ourbalance.domain.model.BalanceInfo
 import javax.inject.Inject
@@ -11,12 +10,12 @@ class BalanceDataSourceImpl @Inject constructor(
     private val balanceService: BalanceService
 ) : BalanceDataSource {
     override suspend fun getBalanceList(): List<BalanceInfo> {
-        return getResponse(balanceService.getBalanceList()).balanceList.map {
+        return balanceService.getBalanceList().balanceList.map {
             it.toModel()
         }
     }
 
     override suspend fun getBalanceDetail(id: Long): BalanceDetail {
-        return getResponse(balanceService.getBalanceDetail(id)).toModel()
+        return balanceService.getBalanceDetail(id).toModel()
     }
 }

--- a/data/src/main/java/com/ourbalance/data/source/remote/balance/BalanceDataSourceImpl.kt
+++ b/data/src/main/java/com/ourbalance/data/source/remote/balance/BalanceDataSourceImpl.kt
@@ -2,43 +2,21 @@ package com.ourbalance.data.source.remote.balance
 
 import com.ourbalance.data.api.BalanceService
 import com.ourbalance.data.entity.mapper.toModel
+import com.ourbalance.data.ext.getResponse
 import com.ourbalance.domain.model.BalanceDetail
 import com.ourbalance.domain.model.BalanceInfo
-import com.ourbalance.domain.result.Result
 import javax.inject.Inject
 
 class BalanceDataSourceImpl @Inject constructor(
     private val balanceService: BalanceService
 ) : BalanceDataSource {
-    override suspend fun getBalanceList(): Result<List<BalanceInfo>> {
-        return try {
-            val response = balanceService.getBalanceList()
-
-            if (response.status == 200) {
-                Result.Success(
-                    response.data!!.balanceList.map {
-                        it.toModel()
-                    }
-                )
-            } else {
-                Result.Error(response.error!!)
-            }
-        } catch (e: Throwable) {
-            Result.Error(e.message ?: "Unknown Error")
+    override suspend fun getBalanceList(): List<BalanceInfo> {
+        return getResponse(balanceService.getBalanceList()).balanceList.map {
+            it.toModel()
         }
     }
 
-    override suspend fun getBalanceDetail(id: Long): Result<BalanceDetail> {
-        return try {
-            val response = balanceService.getBalanceDetail(id)
-
-            if (response.status == 200) {
-                Result.Success(response.data!!.toModel())
-            } else {
-                Result.Error(response.error!!)
-            }
-        } catch (e: Throwable) {
-            Result.Error(e.message ?: "Unknown Error")
-        }
+    override suspend fun getBalanceDetail(id: Long): BalanceDetail {
+        return getResponse(balanceService.getBalanceDetail(id)).toModel()
     }
 }

--- a/domain/src/main/java/com/ourbalance/domain/repository/BalanceRepository.kt
+++ b/domain/src/main/java/com/ourbalance/domain/repository/BalanceRepository.kt
@@ -2,9 +2,8 @@ package com.ourbalance.domain.repository
 
 import com.ourbalance.domain.model.BalanceDetail
 import com.ourbalance.domain.model.BalanceInfo
-import com.ourbalance.domain.result.Result
 
 interface BalanceRepository {
-    suspend fun getBalanceList(): Result<List<BalanceInfo>>
-    suspend fun getBalanceDetail(id: Long): Result<BalanceDetail>
+    suspend fun getBalanceList(): List<BalanceInfo>
+    suspend fun getBalanceDetail(id: Long): BalanceDetail
 }

--- a/domain/src/main/java/com/ourbalance/domain/usecase/GetBalanceDetailUseCase.kt
+++ b/domain/src/main/java/com/ourbalance/domain/usecase/GetBalanceDetailUseCase.kt
@@ -15,7 +15,7 @@ class GetBalanceDetailUseCase @Inject constructor(
     suspend operator fun invoke(id: Long): Result<BalanceDetail> {
         return try {
             withContext(dispatcher) {
-                balanceRepository.getBalanceDetail(id)
+                Result.Success(balanceRepository.getBalanceDetail(id))
             }
         } catch (e: Throwable) {
             Result.Error(e.message ?: "Unknown Error")

--- a/domain/src/main/java/com/ourbalance/domain/usecase/GetBalanceListUseCase.kt
+++ b/domain/src/main/java/com/ourbalance/domain/usecase/GetBalanceListUseCase.kt
@@ -15,7 +15,7 @@ class GetBalanceListUseCase @Inject constructor(
     suspend operator fun invoke(): Result<List<BalanceInfo>> {
         return try {
             withContext(dispatcher) {
-                balanceRepository.getBalanceList()
+                Result.Success(balanceRepository.getBalanceList())
             }
         } catch (e: Throwable) {
             Result.Error(e.message ?: "Unknown Error")


### PR DESCRIPTION
## 관련 이슈
- close #15 

## 고민했던 부분
### 서버 응답에서 데이터만 꺼내오기
  ```json
  {
    "status": 200,
    "error": null,
    "data": null,
  }
  ```
현재 서버 응답은 위와 같이 응답코드, 에러메시지, 데이터 형태로 이루어져 있다. 응답코드와 메시지는 HTTP 응답 자체에서 가져올 수 있는데 이러한 형태는 한번 더 가공이 필요하다. 그래서 처음에는 BaseResponse 타입을 만들어서 감싸서 가져왔다.
```kotlin
data class BaseResponse<T>(
    @SerializedName("error")
    val error: String?,
    @SerializedName("status")
    val status: Int,
    @SerializedName("data")
    val data: T?
)

interface AuthService {
    @POST("/user/signup")
    suspend fun signup(@Body userInfoEntity: UserInfoEntity): BaseResponse<Unit>

    @POST("/user/login")
    suspend fun login(@Body userInfoEntity: UserInfoEntity): BaseResponse<String>
}
```
때문에 만들어진 응답 처리 로직은 아래와 같다.
```kotlin
fun <T> getResponse(response: BaseResponse<T>): Result<T> {
    return try {
        if (response.status == 200) {
            Result.Success(response.data!!)
        } else {
            Result.Error(response.error!!)
        }
    } catch (e: Throwable) {
        Result.Error(e.message ?: "Unknown Error")
    }
}
```
이것을 인터셉터에서 처리할 수는 없을까 고민하다 [좋은 글](https://modelmaker.tistory.com/entry/Android-Okhttp-Interceptor%EB%A1%9C-%EC%9B%90%ED%95%98%EB%8A%94-%EC%9D%91%EB%8B%B5%EC%9C%BC%EB%A1%9C-%EB%B3%80%ED%98%95%ED%95%98%EA%B8%B0%EC%99%80-Interceptor-Test)을 발견했다. 인터셉터에서 Response를 가공할 수 있는데, 이 때 메시지와 바디에 각각 메시지, data 안에 있는 페이로드를 넣어주면 된다. 인터셉터는 굉장하다. 완성된 코드는 아래와 같다.
```kotlin
class ResponseUnboxingInterceptor : Interceptor {
    override fun intercept(chain: Interceptor.Chain): Response {
        val response = chain.proceed(chain.request())
        val responseJson = response.extractResponseJson()
        val payload = if (responseJson.has(KEY_DATA)) responseJson[KEY_DATA] else EMPTY_JSON

        return response.newBuilder()
            .message(responseJson[KEY_ERROR_MESSAGE].toString())
            .body(payload.toString().toResponseBody())
            .build()
    }
}
```

그리고 기존에는 Result 타입으로 래핑해서 데이터를 전달했는데, 이렇게 하면 가공이 어려워서, 데이터 레이어에서는 예외를 던지기만 하고 도메인 레이어에서 최종적으로 예외를 걸러서 Result 타입으로 래핑하도록 했다.