### PR TITLE
ui: 회원가입 및 로그인 화면 구현

### DIFF
--- a/feature/src/main/java/com/ourbalance/feature/information/InformationActivity.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/InformationActivity.kt
@@ -2,7 +2,12 @@ package com.ourbalance.feature.information
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import com.ourbalance.feature.R
+import com.ourbalance.feature.constant.GREETING
 import com.ourbalance.feature.databinding.ActivityInformationBinding
+import com.ourbalance.feature.information.greeting.GreetingFragment
 
 class InformationActivity : AppCompatActivity() {
     private var _binding: ActivityInformationBinding? = null
@@ -12,5 +17,22 @@ class InformationActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         _binding = ActivityInformationBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                add<GreetingFragment>(R.id.fcv_information, GREETING)
+            }
+        }
+        initViews()
+    }
+
+    private fun initViews() = with(binding) {
+        ibtBack.setOnClickListener {
+            if (supportFragmentManager.backStackEntryCount > 0) {
+                supportFragmentManager.popBackStack()
+            } else {
+                finish()
+            }
+        }
     }
 }

--- a/feature/src/main/java/com/ourbalance/feature/information/InformationActivity.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/InformationActivity.kt
@@ -8,7 +8,9 @@ import com.ourbalance.feature.R
 import com.ourbalance.feature.constant.GREETING
 import com.ourbalance.feature.databinding.ActivityInformationBinding
 import com.ourbalance.feature.information.greeting.GreetingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class InformationActivity : AppCompatActivity() {
     private var _binding: ActivityInformationBinding? = null
     private val binding get() = requireNotNull(_binding)

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/GreetingFragment.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/GreetingFragment.kt
@@ -5,7 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
+import com.ourbalance.feature.R
+import com.ourbalance.feature.constant.LOGIN
 import com.ourbalance.feature.databinding.FragmentGreetingBinding
+import com.ourbalance.feature.information.greeting.login.LoginFragment
 
 class GreetingFragment : Fragment() {
 
@@ -23,6 +28,16 @@ class GreetingFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initViews()
+    }
+
+    private fun initViews() = with(binding) {
+        tvLogin.setOnClickListener {
+            parentFragmentManager.commit {
+                replace<LoginFragment>(R.id.fcv_information, LOGIN)
+                addToBackStack(null)
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/GreetingFragment.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/GreetingFragment.kt
@@ -11,7 +11,9 @@ import com.ourbalance.feature.R
 import com.ourbalance.feature.constant.LOGIN
 import com.ourbalance.feature.databinding.FragmentGreetingBinding
 import com.ourbalance.feature.information.greeting.login.LoginFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class GreetingFragment : Fragment() {
 
     private var _binding: FragmentGreetingBinding? = null

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/login/LoginFragment.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/login/LoginFragment.kt
@@ -5,7 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
+import com.ourbalance.feature.R
+import com.ourbalance.feature.constant.SIGNUP
 import com.ourbalance.feature.databinding.FragmentLoginBinding
+import com.ourbalance.feature.information.greeting.signup.SignupFragment
 
 class LoginFragment : Fragment() {
 
@@ -23,6 +28,17 @@ class LoginFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initViews()
+    }
+
+    private fun initViews() = with(binding) {
+        tvSignup.setOnClickListener {
+            parentFragmentManager.commit {
+                replace<SignupFragment>(R.id.fcv_information, SIGNUP)
+                setReorderingAllowed(true)
+                addToBackStack(null)
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/login/LoginFragment.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/login/LoginFragment.kt
@@ -7,15 +7,24 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.ourbalance.feature.R
 import com.ourbalance.feature.constant.SIGNUP
 import com.ourbalance.feature.databinding.FragmentLoginBinding
 import com.ourbalance.feature.information.greeting.signup.SignupFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class LoginFragment : Fragment() {
 
     private var _binding: FragmentLoginBinding? = null
     private val binding get() = requireNotNull(_binding)
+    private val viewModel by viewModels<LoginViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -28,7 +37,10 @@ class LoginFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
         initViews()
+        observeData()
     }
 
     private fun initViews() = with(binding) {
@@ -37,6 +49,22 @@ class LoginFragment : Fragment() {
                 replace<SignupFragment>(R.id.fcv_information, SIGNUP)
                 setReorderingAllowed(true)
                 addToBackStack(null)
+            }
+        }
+    }
+
+    private fun observeData() = with(binding) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.isValidEmail.collectLatest { isValid ->
+                        tilEmail.error = if (isValid or etEmail.text.toString().isEmpty()) {
+                            null
+                        } else {
+                            getString(R.string.error_email_format)
+                        }
+                    }
+                }
             }
         }
     }

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/login/LoginViewModel.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/login/LoginViewModel.kt
@@ -1,0 +1,50 @@
+package com.ourbalance.feature.information.greeting.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ourbalance.domain.usecase.SignInUserUseCase
+import com.ourbalance.domain.usecase.ValidateEmailUseCase
+import com.ourbalance.domain.usecase.ValidatePasswordUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val validateEmailUseCase: ValidateEmailUseCase,
+    private val validatePasswordUseCase: ValidatePasswordUseCase,
+    private val signInUserUseCase: SignInUserUseCase
+) : ViewModel() {
+
+    val emailInput = MutableStateFlow("")
+    val passwordInput = MutableStateFlow("")
+
+    val isValidEmail: Flow<Boolean> = emailInput.map {
+        validateEmailUseCase(it)
+    }
+
+    private val isValidPassword: Flow<Boolean> = passwordInput.map {
+        validatePasswordUseCase(it)
+    }
+
+    val enable = combine(isValidEmail, isValidPassword) { isValidEmail, isValidPassword ->
+        isValidEmail and isValidPassword
+    }.stateIn(
+        initialValue = false,
+        started = SharingStarted.WhileSubscribed(500),
+        scope = viewModelScope
+    )
+
+    fun login() {
+        viewModelScope.launch {
+            Timber.d("로그인")
+        }
+    }
+}

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/signup/SignupFragment.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/signup/SignupFragment.kt
@@ -23,6 +23,13 @@ class SignupFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initViews()
+    }
+
+    private fun initViews() = with(binding) {
+        tvLogin.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
     }
 
     override fun onDestroyView() {

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/signup/SignupFragment.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/signup/SignupFragment.kt
@@ -5,12 +5,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.ourbalance.feature.R
 import com.ourbalance.feature.databinding.FragmentSignupBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class SignupFragment : Fragment() {
 
     private var _binding: FragmentSignupBinding? = null
     private val binding get() = requireNotNull(_binding)
+    private val viewModel by viewModels<SignupViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,12 +33,51 @@ class SignupFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
         initViews()
+        observeData()
     }
 
     private fun initViews() = with(binding) {
         tvLogin.setOnClickListener {
             parentFragmentManager.popBackStack()
+        }
+    }
+
+    private fun observeData() = with(binding) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.isValidEmail.collectLatest { isValid ->
+                        tilEmail.error = if (isValid or etEmail.text.toString().isEmpty()) {
+                            null
+                        } else {
+                            getString(R.string.error_email_format)
+                        }
+                    }
+                }
+                launch {
+                    viewModel.isValidPassword.collectLatest { isValid ->
+                        tilPassword.error = if (isValid or etPassword.text.toString().isEmpty()) {
+                            null
+                        } else {
+                            getString(R.string.error_password_format)
+                        }
+                    }
+                }
+                launch {
+                    viewModel.isSamePassword.collectLatest { isValid ->
+                        tilConfirmPassword.error = isValid?.let {
+                            if (it) {
+                                null
+                            } else {
+                                getString(R.string.error_password_check)
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/feature/src/main/java/com/ourbalance/feature/information/greeting/signup/SignupViewModel.kt
+++ b/feature/src/main/java/com/ourbalance/feature/information/greeting/signup/SignupViewModel.kt
@@ -1,0 +1,68 @@
+package com.ourbalance.feature.information.greeting.signup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ourbalance.domain.usecase.RegisterUserUseCase
+import com.ourbalance.domain.usecase.ValidateEmailUseCase
+import com.ourbalance.domain.usecase.ValidatePasswordUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class SignupViewModel @Inject constructor(
+    private val validateEmailUseCase: ValidateEmailUseCase,
+    private val validatePasswordUseCase: ValidatePasswordUseCase,
+    private val registerUserUseCase: RegisterUserUseCase
+) : ViewModel() {
+
+    val nicknameInput = MutableStateFlow("")
+    val emailInput = MutableStateFlow("")
+    val passwordInput = MutableStateFlow("")
+    val passwordConfirmInput = MutableStateFlow("")
+
+    val isValidEmail: Flow<Boolean> = emailInput.map {
+        validateEmailUseCase(it)
+    }
+
+    val isValidPassword: Flow<Boolean> = passwordInput.map {
+        validatePasswordUseCase(it)
+    }
+
+    val isSamePassword = combine(passwordInput, passwordConfirmInput) { p1, p2 ->
+        if (p1.isNotEmpty() and p2.isNotEmpty()) {
+            p1 == p2
+        } else {
+            null
+        }
+    }
+
+    val enable = combine(
+        isValidEmail,
+        isValidPassword,
+        isSamePassword
+    ) { isValidEmail, isValidPassword, isSamePassword ->
+        if (isSamePassword != null) {
+            isValidEmail and isValidPassword and isSamePassword
+        } else {
+            false
+        }
+    }.stateIn(
+        initialValue = false,
+        started = SharingStarted.WhileSubscribed(500),
+        scope = viewModelScope
+    )
+
+    fun signup() {
+        viewModelScope.launch {
+            Timber.d("회원가입")
+        }
+    }
+}

--- a/feature/src/main/res/drawable/ic_email.xml
+++ b/feature/src/main/res/drawable/ic_email.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z"/>
+</vector>

--- a/feature/src/main/res/drawable/ic_lock.xml
+++ b/feature/src/main/res/drawable/ic_lock.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/feature/src/main/res/drawable/ic_person.xml
+++ b/feature/src/main/res/drawable/ic_person.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/feature/src/main/res/layout/activity_information.xml
+++ b/feature/src/main/res/layout/activity_information.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -11,5 +12,22 @@
         android:layout_height="match_parent"
         tools:context=".information.InformationActivity">
 
+        <ImageButton
+            android:id="@+id/ibt_back"
+            android:layout_width="@dimen/button_size"
+            android:layout_height="@dimen/button_size"
+            android:layout_margin="@dimen/space_default"
+            android:background="@null"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_prev"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fcv_information"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ibt_back" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/src/main/res/layout/fragment_greeting.xml
+++ b/feature/src/main/res/layout/fragment_greeting.xml
@@ -12,13 +12,31 @@
         android:layout_height="match_parent"
         tools:context=".information.greeting.GreetingFragment">
 
-        <TextView
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Greeting"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="@dimen/space_normal" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/TitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_large"
+            android:text="@string/greeting_title"
+            app:layout_constraintStart_toStartOf="@id/gl_start"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_login"
+            style="@style/PlainText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_normal"
+            android:text="@string/navigate_to_login"
+            app:layout_constraintStart_toStartOf="@id/gl_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/src/main/res/layout/fragment_login.xml
+++ b/feature/src/main/res/layout/fragment_login.xml
@@ -5,6 +5,10 @@
 
     <data>
 
+        <variable
+            name="vm"
+            type="com.ourbalance.feature.information.greeting.login.LoginViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -36,16 +40,18 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_normal"
-            android:layout_marginTop="@dimen/space_default"
-            android:hint="@string/hint_for_email"
+            android:layout_marginTop="@dimen/space_normal"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             app:startIconDrawable="@drawable/ic_person">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_email"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:hint="@string/hint_for_email"
                 android:inputType="text"
-                android:maxLines="1" />
+                android:maxLines="1"
+                android:text="@={vm.emailInput}" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -54,23 +60,26 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_normal"
-            android:layout_marginTop="@dimen/space_default"
-            android:hint="@string/hint_for_password"
             app:layout_constraintTop_toBottomOf="@id/til_email"
             app:startIconDrawable="@drawable/ic_email">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:hint="@string/hint_for_password"
                 android:inputType="textPassword"
-                android:maxLines="1" />
+                android:maxLines="1"
+                android:text="@={vm.passwordInput}" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
             android:id="@+id/btn_login"
             android:layout_width="@dimen/large_button_width"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:enabled="@{vm.enable}"
+            android:onClick="@{() -> vm.login()}"
             android:paddingVertical="@dimen/space_padding"
             android:text="@string/button_login"
             android:textStyle="bold"

--- a/feature/src/main/res/layout/fragment_login.xml
+++ b/feature/src/main/res/layout/fragment_login.xml
@@ -12,13 +12,96 @@
         android:layout_height="match_parent"
         tools:context=".information.greeting.login.LoginFragment">
 
-        <TextView
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="LoginFragment"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="@dimen/space_normal" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/TitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_normal"
+            android:text="@string/sign_in_title"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_email"
+            style="@style/TextInputStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:hint="@string/hint_for_email"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            app:startIconDrawable="@drawable/ic_person">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_password"
+            style="@style/TextInputStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:hint="@string/hint_for_password"
+            app:layout_constraintTop_toBottomOf="@id/til_email"
+            app:startIconDrawable="@drawable/ic_email">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/btn_login"
+            android:layout_width="@dimen/large_button_width"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_normal"
+            android:paddingVertical="@dimen/space_padding"
+            android:text="@string/button_login"
+            android:textStyle="bold"
+            app:cornerRadius="50dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/til_password" />
+
+        <TextView
+            android:id="@+id/tv_check_first_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/space_normal"
+            android:text="@string/check_first_time"
+            android:textColor="@color/black"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/tv_signup"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_signup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_signup"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_check_first_time"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/tv_check_first_time" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/src/main/res/layout/fragment_signup.xml
+++ b/feature/src/main/res/layout/fragment_signup.xml
@@ -12,13 +12,132 @@
         android:layout_height="match_parent"
         tools:context=".information.greeting.signup.SignupFragment">
 
-        <TextView
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Signup"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="@dimen/space_normal" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/TitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_normal"
+            android:text="@string/signup_title"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_nickname"
+            style="@style/TextInputStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:hint="@string/hint_for_nickname"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            app:startIconDrawable="@drawable/ic_person">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_email"
+            style="@style/TextInputStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:hint="@string/hint_for_email"
+            app:layout_constraintTop_toBottomOf="@id/til_nickname"
+            app:startIconDrawable="@drawable/ic_email">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textEmailAddress"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_password"
+            style="@style/TextInputStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:hint="@string/hint_for_password"
+            app:layout_constraintTop_toBottomOf="@id/til_email"
+            app:startIconDrawable="@drawable/ic_lock">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_confirm_password"
+            style="@style/TextInputStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:hint="@string/hint_for_check_password"
+            app:layout_constraintTop_toBottomOf="@id/til_password"
+            app:startIconDrawable="@drawable/ic_lock">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/btn_login"
+            android:layout_width="@dimen/large_button_width"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_normal"
+            android:paddingVertical="@dimen/space_padding"
+            android:text="@string/button_signup"
+            android:textStyle="bold"
+            app:cornerRadius="50dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/til_confirm_password" />
+
+        <TextView
+            android:id="@+id/tv_check_exist_account"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/space_normal"
+            android:text="@string/check_exist_account"
+            android:textColor="@color/black"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/tv_login"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_login"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_login"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_check_exist_account"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/tv_check_exist_account" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/src/main/res/layout/fragment_signup.xml
+++ b/feature/src/main/res/layout/fragment_signup.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="vm"
+            type="com.ourbalance.feature.information.greeting.signup.SignupViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -36,16 +39,18 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_normal"
-            android:layout_marginTop="@dimen/space_default"
-            android:hint="@string/hint_for_nickname"
+            android:layout_marginTop="@dimen/space_normal"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             app:startIconDrawable="@drawable/ic_person">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_nickname"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:hint="@string/hint_for_nickname"
                 android:inputType="text"
-                android:maxLines="1" />
+                android:maxLines="1"
+                android:text="@={vm.nicknameInput}" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -54,16 +59,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_normal"
-            android:layout_marginTop="@dimen/space_default"
-            android:hint="@string/hint_for_email"
             app:layout_constraintTop_toBottomOf="@id/til_nickname"
             app:startIconDrawable="@drawable/ic_email">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_email"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:hint="@string/hint_for_email"
                 android:inputType="textEmailAddress"
-                android:maxLines="1" />
+                android:maxLines="1"
+                android:text="@={vm.emailInput}" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -72,16 +78,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_normal"
-            android:layout_marginTop="@dimen/space_default"
-            android:hint="@string/hint_for_password"
             app:layout_constraintTop_toBottomOf="@id/til_email"
             app:startIconDrawable="@drawable/ic_lock">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:hint="@string/hint_for_password"
                 android:inputType="textPassword"
-                android:maxLines="1" />
+                android:maxLines="1"
+                android:text="@={vm.passwordInput}" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -90,23 +97,26 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_normal"
-            android:layout_marginTop="@dimen/space_default"
-            android:hint="@string/hint_for_check_password"
             app:layout_constraintTop_toBottomOf="@id/til_password"
             app:startIconDrawable="@drawable/ic_lock">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_confirm_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:hint="@string/hint_for_check_password"
                 android:inputType="textPassword"
-                android:maxLines="1" />
+                android:maxLines="1"
+                android:text="@={vm.passwordConfirmInput}" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
-            android:id="@+id/btn_login"
+            android:id="@+id/btn_signup"
             android:layout_width="@dimen/large_button_width"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/space_normal"
+            android:layout_marginTop="@dimen/space_default"
+            android:enabled="@{vm.enable}"
+            android:onClick="@{()->vm.signup()}"
             android:paddingVertical="@dimen/space_padding"
             android:text="@string/button_signup"
             android:textStyle="bold"

--- a/feature/src/main/res/values/dimens.xml
+++ b/feature/src/main/res/values/dimens.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="space_default">16dp</dimen>
+    <dimen name="space_padding">12dp</dimen>
     <dimen name="space_text">8dp</dimen>
+    <dimen name="space_large">48dp</dimen>
+    <dimen name="space_normal">32dp</dimen>
     <dimen name="radius_size">8dp</dimen>
+    <dimen name="radius_large">16dp</dimen>
     <dimen name="text_size_heading">32sp</dimen>
     <dimen name="text_size_subtitle">28sp</dimen>
     <dimen name="text_size_body1">18sp</dimen>
@@ -10,4 +14,6 @@
     <dimen name="text_size_caption">14sp</dimen>
     <dimen name="balance_bar_height">48dp</dimen>
     <dimen name="balance_bar_stroke_width">2dp</dimen>
+    <dimen name="button_size">40dp</dimen>
+    <dimen name="large_button_width">200dp</dimen>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -4,4 +4,16 @@
     <string name="main_login_message">로그인 / 회원가입하여\n 밸런스 리스트를 추가해보세요</string>
     <string name="main_empty_message">하단의 + 버튼을 눌러\n 새로운 밸런스 항목을 생성해보세요</string>
     <string name="main_waiting_message">waiting..</string>
+    <string name="greeting_title">안녕하세요\nBalance입니다</string>
+    <string name="navigate_to_login">회원가입 및 로그인</string>
+    <string name="sign_in_title">Sign In</string>
+    <string name="hint_for_nickname">사용하실 닉네임을 입력해주세요</string>
+    <string name="hint_for_email">이메일을 입력해주세요</string>
+    <string name="hint_for_password">비밀번호를 입력해주세요</string>
+    <string name="hint_for_check_password">비밀번호를 확인해주세요</string>
+    <string name="button_login">로그인</string>
+    <string name="button_signup">회원가입</string>
+    <string name="check_first_time">처음이신가요?</string>
+    <string name="check_exist_account">이미 계정이 있다면?</string>
+    <string name="signup_title">Create Account</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -16,4 +16,7 @@
     <string name="check_first_time">처음이신가요?</string>
     <string name="check_exist_account">이미 계정이 있다면?</string>
     <string name="signup_title">Create Account</string>
+    <string name="error_email_format">이메일 형식이 아닙니다.</string>
+    <string name="error_password_format">비밀번호는 6~15자리로 입력해주세요.</string>
+    <string name="error_password_check">비밀번호가 일치하지 않습니다.</string>
 </resources>

--- a/feature/src/main/res/values/style_button.xml
+++ b/feature/src/main/res/values/style_button.xml
@@ -9,5 +9,7 @@
         <item name="boxStrokeColor">@color/black</item>
         <item name="boxStrokeWidth">@dimen/balance_bar_stroke_width</item>
         <item name="startIconTint">@color/black</item>
+        <item name="hintEnabled">false</item>
+        <item name="errorEnabled">true</item>
     </style>
 </resources>

--- a/feature/src/main/res/values/style_button.xml
+++ b/feature/src/main/res/values/style_button.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="TextInputStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+        <item name="boxCornerRadiusBottomEnd">@dimen/radius_large</item>
+        <item name="boxCornerRadiusBottomStart">@dimen/radius_large</item>
+        <item name="boxCornerRadiusTopEnd">@dimen/radius_large</item>
+        <item name="boxCornerRadiusTopStart">@dimen/radius_large</item>
+        <item name="boxStrokeColor">@color/black</item>
+        <item name="boxStrokeWidth">@dimen/balance_bar_stroke_width</item>
+        <item name="startIconTint">@color/black</item>
+    </style>
+</resources>

--- a/feature/src/main/res/values/style_text.xml
+++ b/feature/src/main/res/values/style_text.xml
@@ -14,4 +14,10 @@
         <item name="android:textColor">@color/black</item>
         <item name="android:textSize">@dimen/text_size_body2</item>
     </style>
+
+    <style name="PlainText">
+        <item name="android:lineSpacingExtra">@dimen/space_default</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">@dimen/text_size_body2</item>
+    </style>
 </resources>

--- a/feature/src/main/res/values/themes.xml
+++ b/feature/src/main/res/values/themes.xml
@@ -2,7 +2,7 @@
     <!-- Base application theme. -->
     <style name="Theme.OurBalance" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimary">@color/black</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->


### PR DESCRIPTION
## 관련 이슈
- close #27

## 주요 구현 사항
- 회원가입 및 로그인 화면 UI 구현

## 스크린샷
<p>
<img width="250" alt="greeting" src="https://user-images.githubusercontent.com/78132126/193416861-8306df54-cfe0-4857-a3d5-ffee4ed79d2c.png">
<img width="250" alt="login" src="https://user-images.githubusercontent.com/78132126/193416872-f576193c-b674-40ea-b0cb-4217f0277fee.png">
<img width="250" alt="signup" src="https://user-images.githubusercontent.com/78132126/193416881-ccb0a6d8-73e3-4b7e-9af8-c205bd10737b.png">
</p>

### 유효성 검사
<img width="250" alt="validation" src="https://user-images.githubusercontent.com/78132126/193416928-ab5fedb0-8ce7-4999-a1a1-b7c5fb23dd06.png">

## 고민했던 부분
### Configuration Change
다크모드로 전환하거나 화면을 회전하는 경우 Configuration change 이벤트로 인해 화면을 다시 그리게 된다. 이때 초기 프래그먼트를 그리는 코드가 실행되어 초기 상태로 돌아가는 문제가 있었다. 
```kotlin
override fun onCreate(savedInstanceState: Bundle?) {
    super.onCreate(savedInstanceState)
    _binding = ActivityInformationBinding.inflate(layoutInflater)
    setContentView(binding.root)

    supportFragmentManager.commit {
        add<GreetingFragment>(R.id.fcv_information, GREETING)
    }
    initViews()
}
```
여러가지 테스트 결과, 화면을 다시 그리더라도 `fragmentManager`의 `backStackEntryCount`는 변하지 않는다는 것을 확인했다. 이 말은 `fragmentManager`는 그동안 수행한 트랜잭션을 번들에 저장한다는 의미가 된다. 그렇기 때문에 초기 프래그먼트를 그리기 전에 번들을 체크하는 코드만 넣으면 깔끔하게 해결된다.
```kotlin
override fun onCreate(savedInstanceState: Bundle?) {
    super.onCreate(savedInstanceState)
    _binding = ActivityInformationBinding.inflate(layoutInflater)
    setContentView(binding.root)

    if (savedInstanceState == null) {
        supportFragmentManager.commit {
            add<GreetingFragment>(R.id.fcv_information, GREETING)
        }
    }
    initViews()
}
```

### UI 제어를 위한 Flow 사용
회원가입 화면에서 데이터가 변경될 때마다 유효성 검사를 수행하고, 버튼 활성화 상태를 변경해야 한다. 해당 작업을 위해 `StateFlow`와 `Two-way DataBinding` 그리고 `combine()`을 적절하게 사용했다. 데이터바인딩을 사용하면 뷰모델의 데이터를 뷰와 연결해 코드가 간결해진다. 

```xml
<com.google.android.material.textfield.TextInputEditText
    android:id="@+id/et_email"
    android:layout_width="match_parent"
    android:layout_height="wrap_content"
    android:hint="@string/hint_for_email"
    android:inputType="text"
    android:maxLines="1"
    android:text="@={vm.emailInput}" />
```
`EditText`의 `text` 값은 양방향으로 연결해서 텍스트 값이 변경될 때마다 뷰모델의 값을 업데이트한다. 

```kotlin
val emailInput = MutableStateFlow("")
val isValidEmail: Flow<Boolean> = emailInput.map {
    validateEmailUseCase(it)
}
```
뷰모델에서는 값이 업데이트 될때마다 유효성 검사를 수행한다.

```kotlin
val enable = combine(isValidEmail, isValidPassword) { isValidEmail, isValidPassword ->
    isValidEmail and isValidPassword
}.stateIn(
    initialValue = false,
    started = SharingStarted.WhileSubscribed(500),
    scope = viewModelScope
)
```
마지막으로 이메일 유효성검사와 비밀번호 유효성 검사 결과를 `combine()`으로 결합한다. 어느 한쪽에서라도 새로운 데이터가 발행되면 주어진 로직을 수행하고 값을 반환한다. `combine()`의 반환값은 `Flow` 형태이지만 데이터바인딩을 위해 `stateIn()`을 통해 `stateFlow`로 바꿔주었다. 