### PR TITLE
ui: 밸런스 항목 커스텀 뷰 구현

### DIFF
--- a/feature/src/main/java/com/ourbalance/feature/view/BalanceBar.kt
+++ b/feature/src/main/java/com/ourbalance/feature/view/BalanceBar.kt
@@ -1,0 +1,101 @@
+package com.ourbalance.feature.view
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Paint.ANTI_ALIAS_FLAG
+import android.graphics.Path
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.annotation.ColorInt
+import com.ourbalance.feature.R
+
+class BalanceBar constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs) {
+
+    private lateinit var borderRect: RectF
+    private lateinit var ratioRect: RectF
+    private lateinit var borderPath: Path
+    private lateinit var ratioPath: Path
+
+    private val cornerRadius = 32f
+    private var fillColor: Int = Color.YELLOW
+    private var ratio = 0
+    private var w: Int = 0
+    private var h: Int = 0
+
+    private val strokePaint: Paint = Paint(ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = 6f
+        color = Color.BLACK
+    }
+
+    private val paint: Paint = Paint(ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+        color = fillColor
+    }
+
+    init {
+        context.theme.obtainStyledAttributes(attrs, R.styleable.BalanceBar, 0, 0).apply {
+            try {
+                fillColor = getColor(R.styleable.BalanceBar_fillColor, 0)
+                ratio = getInteger(R.styleable.BalanceBar_ratio, 0)
+            } finally {
+                recycle()
+            }
+        }
+    }
+
+    fun setFillColor(@ColorInt color: Int) {
+        fillColor = color
+        invalidate()
+    }
+
+    fun setRatio(ratio: Int) {
+        this.ratio = ratio
+        drawRatioRect(ratio)
+        invalidate()
+    }
+
+    private fun drawRatioRect(ratio: Int) {
+        ratioRect =
+            RectF(0f, 0f, w.toFloat() * ratio / 100, h.toFloat()).apply {
+                inset(strokePaint.strokeWidth / 2, strokePaint.strokeWidth / 2)
+            }
+
+        ratioPath = Path().apply {
+            addRect(ratioRect, Path.Direction.CW)
+            op(borderPath, Path.Op.INTERSECT)
+        }
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        this.w = w
+        this.h = h
+
+        borderRect = RectF(0f, 0f, w.toFloat(), h.toFloat()).apply {
+            inset(strokePaint.strokeWidth / 2, strokePaint.strokeWidth / 2)
+        }
+
+        borderPath = Path().apply {
+            addRoundRect(borderRect, cornerRadius, cornerRadius, Path.Direction.CW)
+        }
+
+        drawRatioRect(ratio)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        with(canvas) {
+            drawPath(ratioPath, paint)
+            drawPath(ratioPath, strokePaint)
+            drawPath(borderPath, strokePaint)
+        }
+    }
+}

--- a/feature/src/main/res/layout/item_balance.xml
+++ b/feature/src/main/res/layout/item_balance.xml
@@ -28,15 +28,14 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="방이름" />
 
-        <ProgressBar
+        <com.ourbalance.feature.view.BalanceBar
             android:id="@+id/view_balance"
-            style="?android:attr/progressBarStyleHorizontal"
             android:layout_width="match_parent"
             android:layout_height="@dimen/balance_bar_height"
             android:layout_marginTop="@dimen/space_text"
-            android:progress="@{item.me.ratio}"
-            android:progressDrawable="@drawable/bg_balance_item"
-            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+            app:fillColor="@color/yellow"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            app:ratio="@{item.me.ratio}" />
 
         <TextView
             android:id="@+id/tv_waiting"

--- a/feature/src/main/res/values/attrs.xml
+++ b/feature/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="BalanceBar">
+        <attr name="fillColor" format="color" />
+        <attr name="ratio" format="integer" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
## 관련 이슈
- close #29 

## 주요 구현 사항
- 커스텀 뷰 구현

## 고민했던 부분
### 관련 메서드
- `onSizeChanged()` : 뷰의 크기가 변경될 때 호출
- `onDraw()` :  실제로 그리는 부분
- `invalidate()` : 다시 그림
### 커스텀 뷰와 데이터바인딩
- 데이터 초기화 시점 이슈로 데이터 바인딩을 사용하려면 setter가 필요함
- setter에서 `invalidate()`호출하여 뷰를 다시 그려줘야 함!
